### PR TITLE
Fixed issue regarding not displaying user's registered name

### DIFF
--- a/lib/user/AuthContext.tsx
+++ b/lib/user/AuthContext.tsx
@@ -216,8 +216,8 @@ function AuthProvider({ children }: React.PropsWithChildren<Record<string, any>>
     setUser({
       id: uid,
       token,
-      firstName: displayName,
-      lastName: '',
+      firstName: userData.user.firstName,
+      lastName: userData.user.lastName,
       preferredEmail: email,
       photoUrl: photoURL,
       permissions, // probably not the best way to do this, but it works for hackutd and that's what matters

--- a/pages/dashboard/Components/Sidebar.tsx
+++ b/pages/dashboard/Components/Sidebar.tsx
@@ -18,7 +18,7 @@ function Sidebar() {
         id="Sidebar"
         className="hidden md:flex flex-col content-center justify-center items-center h-screen fixed top-16 border-r-2 border-t-2 border-gray-600 lg:w-1/8 md:w-1/7 w-1/6 text-xs lg:text-sm text-center"
       >
-        <div>Welcome, {!user || !isSignedIn ? 'hacker' : user.firstName}</div>
+        <div>Welcome, {!user || !isSignedIn ? 'hacker' : user.firstName + ' ' + user.lastName}</div>
         <div className="text-indigo-500">{role}</div>
       </section>
     </>

--- a/pages/dashboard/hackerpack.tsx
+++ b/pages/dashboard/hackerpack.tsx
@@ -67,7 +67,9 @@ export default function HackerPack() {
           </ul>
         </section>
         <div className="dashboardTag fixed bottom-0 border-t-2 border-r-2 border-aqua w-1/4 md:w-1/6 2xl:w-1/8 text-center py-3 bg-black">
-          <div>Welcome, {!user || !isSignedIn ? 'hacker' : user.firstName}</div>
+          <div>
+            Welcome, {!user || !isSignedIn ? 'hacker' : user.firstName + ' ' + user.lastName}
+          </div>
           <div className="text-indigo-500">{role}</div>
         </div>
       </section>

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -35,7 +35,7 @@ export default function ProfilePage() {
           setUserData({
             id: user.uid,
             preferredEmail: user.email,
-            name: user.displayName,
+            name: `${data.user.firstName} ${data.user.lastName}`,
             permissions: data.user.permissions,
             photoUrl: user.photoURL,
             university: data.university,


### PR DESCRIPTION
This PR is meant to address the issue regarding the portal displaying name that is associated to the Google account instead of name that user registered. 